### PR TITLE
⚡ Bolt: optimize read-only mongoose queries with .lean()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Use `.lean()` for Read-Only Mongoose Queries
+**Learning:** Mongoose queries return fully hydrated Mongoose documents by default, which have overhead for saving, getters/setters, etc. If the result is only going to be sent back as a JSON response (read-only), this overhead is completely unnecessary and creates a performance bottleneck in the codebase.
+**Action:** Always append `.lean()` to Mongoose read-only queries (`find`, `findOne`, `findById`) whose results are directly returned as JSON responses.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
 ## 2024-05-24 - Use `.lean()` for Read-Only Mongoose Queries
-**Learning:** Mongoose queries return fully hydrated Mongoose documents by default, which have overhead for saving, getters/setters, etc. If the result is only going to be sent back as a JSON response (read-only), this overhead is completely unnecessary and creates a performance bottleneck in the codebase.
-**Action:** Always append `.lean()` to Mongoose read-only queries (`find`, `findOne`, `findById`) whose results are directly returned as JSON responses.
+**Learning:** Mongoose queries return fully hydrated Mongoose documents by default, which have overhead for saving and document features such as getters/setters, virtuals, defaults, middleware, and instance methods. Using `.lean()` can improve performance for read-only queries, but it changes the returned value from a Mongoose document to a plain object.
+**Action:** Append `.lean()` to Mongoose read-only queries (`find`, `findOne`, `findById`) only when the response does not rely on Mongoose document features. If the response needs features such as virtuals or getters, either avoid `.lean()` or enable the required lean options where supported.

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -6,6 +6,8 @@ const auth = require('../middleware/auth');
 // Get messages between two users
 router.get('/:userId', auth, async (req, res) => {
   try {
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // This skips Mongoose document hydration, optimizing response time and memory for read-only JSON results
     const messages = await Message.find({
       $or: [
         { sender: req.user.userId, recipient: req.params.userId },
@@ -16,7 +18,8 @@ router.get('/:userId', auth, async (req, res) => {
     .limit(50)
     .populate('sender', 'username profilePicture')
     .populate('recipient', 'username profilePicture')
-    .populate('replyTo');
+    .populate('replyTo')
+    .lean();
 
     res.json(messages.reverse());
   } catch (error) {

--- a/routes/stories.js
+++ b/routes/stories.js
@@ -29,6 +29,8 @@ router.post('/', auth, async (req, res) => {
 // Get stories from users you follow
 router.get('/feed', auth, async (req, res) => {
   try {
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // This reduces overhead by skipping Mongoose document hydration for JSON-only results
     const stories = await Story.find({
       user: { $in: req.user.following },
       isActive: true,
@@ -36,7 +38,8 @@ router.get('/feed', auth, async (req, res) => {
     })
     .sort({ createdAt: -1 })
     .populate('user', 'username profilePicture')
-    .populate('viewers.user', 'username profilePicture');
+    .populate('viewers.user', 'username profilePicture')
+    .lean();
 
     res.json(stories);
   } catch (error) {
@@ -47,13 +50,16 @@ router.get('/feed', auth, async (req, res) => {
 // Get user's own stories
 router.get('/my-stories', auth, async (req, res) => {
   try {
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // This reduces overhead by skipping Mongoose document hydration for JSON-only results
     const stories = await Story.find({
       user: req.user.userId,
       isActive: true,
       expiresAt: { $gt: new Date() }
     })
     .sort({ createdAt: -1 })
-    .populate('viewers.user', 'username profilePicture');
+    .populate('viewers.user', 'username profilePicture')
+    .lean();
 
     res.json(stories);
   } catch (error) {

--- a/routes/users.js
+++ b/routes/users.js
@@ -6,10 +6,13 @@ const auth = require('../middleware/auth');
 // Get user profile
 router.get('/:userId', auth, async (req, res) => {
   try {
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // This prevents Mongoose from returning fully hydrated documents with unnecessary overhead
     const user = await User.findById(req.params.userId)
       .select('-password')
       .populate('followers', 'username profilePicture')
-      .populate('following', 'username profilePicture');
+      .populate('following', 'username profilePicture')
+      .lean();
 
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
@@ -112,6 +115,8 @@ router.post('/:userId/unfollow', auth, async (req, res) => {
 router.get('/search/:query', auth, async (req, res) => {
   try {
     const searchQuery = req.params.query;
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // This skips Mongoose hydration which improves query speed and reduces memory usage
     const users = await User.find({
       $or: [
         { username: { $regex: searchQuery, $options: 'i' } },
@@ -119,7 +124,8 @@ router.get('/search/:query', auth, async (req, res) => {
       ]
     })
     .select('-password')
-    .limit(10);
+    .limit(10)
+    .lean();
 
     res.json(users);
   } catch (error) {


### PR DESCRIPTION
💡 What: Appended `.lean()` to read-only Mongoose queries (`find` and `findById`) across multiple route files (`users.js`, `messages.js`, `stories.js`).

🎯 Why: Mongoose queries return fully hydrated Mongoose documents by default, which have overhead for saving, getters/setters, etc. If the result is only going to be sent back as a JSON response (read-only), this overhead is completely unnecessary and creates a performance bottleneck in the backend codebase.

📊 Impact: Reduces response times and memory usage for database fetches by skipping the hydration process entirely, resulting in faster and lighter read requests.

🔬 Measurement: Verify the improvement by running a load test comparing memory and request times of endpoint queries before and after the change, or simply start the server to confirm it responds successfully to fetching data.

---
*PR created automatically by Jules for task [13347133404517689078](https://jules.google.com/task/13347133404517689078) started by @KAUSHAL36977*