### PR TITLE
⚡ Bolt: [performance improvement] Optimize Add Reaction Endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2026-05-31 - Atomic Array Updates & Concurrency
 **Learning:** Replacing `findById()` + manual array manipulation + `save()` with atomic `updateOne()` operations (e.g., using `$ne` checks and `$push`) not only avoids full document hydration overhead but also eliminates race conditions in high-concurrency endpoints like view tracking.
 **Action:** Prioritize native MongoDB array operators (`$addToSet`, `$pull`, `$push` with `$ne`) over application-level array manipulation whenever possible.
+## 2026-06-03 - Atomic Array Updates & Avoiding Race Conditions
+**Learning:** Replacing a read-modify-write pattern with multiple atomic updates (e.g., trying an update and falling back to a push) can introduce TOCTOU race conditions where concurrent requests insert duplicate data, bypassing Mongoose's optimistic concurrency control.
+**Action:** When performing atomic upsert-like array operations, use query operators like `$ne` within the update query filter (`{ 'array.user': { $ne: req.user.userId } }`) to ensure duplicates cannot be pushed concurrently.

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -84,25 +84,34 @@ router.put('/read/:senderId', auth, async (req, res) => {
 router.post('/:messageId/reactions', auth, async (req, res) => {
   try {
     const { emoji } = req.body;
-    const message = await Message.findById(req.params.messageId);
 
-    if (!message) {
+    // ⚡ Bolt: Replaced findById() + memory manipulation + save() with atomic operations
+    // Why: Eliminates full document hydration overhead and reduces potential race conditions during concurrent reactions.
+    // Impact: Significantly reduces memory footprint and optimizes database roundtrips by attempting an in-place update first.
+    // Measurement: Compare memory usage and response times for the reactions endpoint under concurrent load.
+
+    // First, attempt to push a new reaction ONLY if the user hasn't reacted yet.
+    // This prevents race conditions that could lead to duplicate reactions.
+    let updatedMessage = await Message.findOneAndUpdate(
+      { _id: req.params.messageId, 'reactions.user': { $ne: req.user.userId } },
+      { $push: { reactions: { user: req.user.userId, emoji } } },
+      { new: true, runValidators: true }
+    );
+
+    // If that returned null, the user already reacted, so we update the existing reaction.
+    if (!updatedMessage) {
+      updatedMessage = await Message.findOneAndUpdate(
+        { _id: req.params.messageId, 'reactions.user': req.user.userId },
+        { $set: { 'reactions.$.emoji': emoji } },
+        { new: true, runValidators: true }
+      );
+    }
+
+    if (!updatedMessage) {
       return res.status(404).json({ message: 'Message not found' });
     }
 
-    // Remove existing reaction from the same user
-    message.reactions = message.reactions.filter(
-      reaction => reaction.user.toString() !== req.user.userId
-    );
-
-    // Add new reaction
-    message.reactions.push({
-      user: req.user.userId,
-      emoji
-    });
-
-    await message.save();
-    res.json(message);
+    res.json(updatedMessage);
   } catch (error) {
     res.status(500).json({ message: 'Error adding reaction', error: error.message });
   }


### PR DESCRIPTION
💡 What: Replaced `findById()` + in-memory array manipulation + `save()` with atomic MongoDB operations (`findOneAndUpdate` with `$push` and `$set`) for the `Add reaction to message` endpoint.
🎯 Why: The original pattern was prone to Time-of-Check to Time-of-Use (TOCTOU) race conditions when concurrent requests were made, and it incurred significant overhead by forcing Mongoose to fully hydrate the entire message document simply to append a single array item.
📊 Impact: Considerably reduces database latency and application memory footprint by avoiding full document hydration. Furthermore, it completely eliminates race conditions that could yield duplicate reactions for the same user.
🔬 Measurement: Compare API response time and memory footprint (via Node.js profiler) for the `/:messageId/reactions` endpoint under high concurrent load before and after this change.

---
*PR created automatically by Jules for task [7351250478924264267](https://jules.google.com/task/7351250478924264267) started by @KAUSHAL36977*