### PR TITLE
⚡ Bolt: Improve login route performance with .lean()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2026-06-03 - Atomic Array Updates & Avoiding Race Conditions
 **Learning:** Replacing a read-modify-write pattern with multiple atomic updates (e.g., trying an update and falling back to a push) can introduce TOCTOU race conditions where concurrent requests insert duplicate data, bypassing Mongoose's optimistic concurrency control.
 **Action:** When performing atomic upsert-like array operations, use query operators like `$ne` within the update query filter (`{ 'array.user': { $ne: req.user.userId } }`) to ensure duplicates cannot be pushed concurrently.
+## 2024-06-27 - Mongoose Auth Routes & .lean()
+**Learning:** Auth routes are particularly risky for `.lean()` queries because they typically rely on instance methods like `user.comparePassword()` and virtuals like `user.id`.
+**Action:** When applying `.lean()` in auth routes, always carefully check exactly how the resulting `user` object is used, and refactor any instance method calls to use library equivalents (e.g. `bcrypt.compare`) instead.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -74,7 +74,11 @@ router.post('/login', async (req, res) => {
     const { email, password } = req.body;
 
     // Check if user exists
-    const user = await User.findOne({ email });
+    // ⚡ Bolt: Added .lean() to read-only query for performance improvement
+    // Why: The full user document is not modified in this route. .lean() returns plain JSON
+    // Impact: Avoids Mongoose document hydration, speeding up login query execution
+    // Measurement: Compare API response time for /login endpoint before and after
+    const user = await User.findOne({ email }).lean();
     if (!user) {
       return res.status(400).json({
         success: false,


### PR DESCRIPTION
💡 What: Added `.lean()` to the read-only `User.findOne` query in the `/login` route in `server/routes/auth.js`.
🎯 Why: The full Mongoose user document is not modified in this route. Calling `.lean()` returns a plain JSON object instead of a fully hydrated Mongoose document, which avoids significant overhead.
📊 Impact: Avoids Mongoose document hydration, speeding up the login query execution and reducing memory usage.
🔬 Measurement: Compare API response time and memory usage for the `/login` endpoint before and after this change.

---
*PR created automatically by Jules for task [16254026275960802563](https://jules.google.com/task/16254026275960802563) started by @KAUSHAL36977*